### PR TITLE
Fix WordPress versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Notable project changes. Versions are [semantic][].
 
 ## [Unreleased][]
 
-No unreleased changes.
+### Fixed
+
+- WordPress versioning for X.Y.0 versions
 
 ## [0.1.2][] - 2022-01-18
 

--- a/src/init.sh
+++ b/src/init.sh
@@ -67,7 +67,7 @@ echo "$NODE_VER" | grep -iq '[a-z_-]' || NODE_VER="$(printf '%s.0.0' "$NODE_VER"
 echo "$PERL_VER" | grep -iq '[a-z_-]' || PERL_VER="$(printf '%s.0.0' "$PERL_VER" | cut -d. -f-3 | sed 's/^\.0\.0$//')"
 echo "$PYTHON_VER" | grep -iq '[a-z_-]' || PYTHON_VER="$(printf '%s.0.0' "$PYTHON_VER" | cut -d. -f-3 | sed 's/^\.0\.0$//')"
 echo "$RUBY_VER" | grep -iq '[a-z_-]' || RUBY_VER="$(printf '%s.0.0' "$RUBY_VER" | cut -d. -f-3 | sed 's/^\.0\.0$//')"
-echo "$WP_VER" | grep -iq '[a-z_-]' || WP_VER="$(printf '%s.0.0' "$WP_VER" | cut -d. -f-3 | sed 's/^\.0\.0$//')"
+echo "$WP_VER" | grep -iq '[a-z_-]' || WP_VER="$(printf '%s.0.0' "$WP_VER" | cut -d. -f-3 | sed 's/^\.0\.0$//' | sed 's/\.0$//')"
 PHP_VER="$(printf '%s.0.0' "$PHP_VER" | cut -d. -f-2 | sed 's/^\.0$//')"
 
 : >/tmp/prov-key


### PR DESCRIPTION
<!--
Provide a brief, descriptive summary of your changes in the title above.

Use appropriate labels to identify the changes in this request.

Delete this commented-out section before submitting your request.
-->

**Description**\
Fixes WordPress versioning for X.Y.0 versions.

**Context**\
WP-CLI can't install version 4.7.0, for example, but does recognize version 4.7. Any X.Y.0 version needs to have the trailing .0 trimmed.

**Verification**\
Provide a clear and concise explanation here for any items not checked below.

- [x] I have read this project's code of conduct
- [x] I have read this project's contributing guidelines
- [x] I have followed this project's coding standards
- [x] I have followed this project's documentation standards
- [x] I have added passing tests to verify changes
