### PR TITLE
Update Vagrantfile for ARM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 Vagrant.configure('2') do |config|
+  ENV['ARCH'] ||= ''
   ENV['HOST'] ||= '_ sys._'
   ENV['ZONE'] ||= 'America/Detroit'
 
@@ -9,13 +10,11 @@ Vagrant.configure('2') do |config|
   npmrc = File.join(Dir.home, '.npmrc')
   vimrc = File.join(Dir.home, '.vimrc')
 
-  config.vm.provider 'virtualbox' do |vb|
-    vb.memory = 1024
-  end
-
   config.vm.box = 'debian/contrib-buster64'
+  config.vm.box = 'bento/debian-11.2-arm64' if ENV['ARCH'].include? 'arm'
   config.vm.hostname = File.basename(Dir.pwd) + '.test'
   config.vm.network 'private_network', type: 'dhcp'
+  config.vm.provision 'shell', inline: 'echo "options single-request-reopen" >> /etc/resolv.conf' if ENV['ARCH'].include? 'arm'
   config.vm.provision 'file', source: bash_aliases, destination: '~/.bash_aliases' if File.file?(bash_aliases)
   config.vm.provision 'file', source: bash_profile, destination: '~/.bash_profile' if File.file?(bash_profile)
   config.vm.provision 'file', source: gitconfig, destination: '~/.gitconfig' if File.file?(gitconfig)


### PR DESCRIPTION
<!--
Provide a brief, descriptive summary of your changes in the title above.

Use appropriate labels to identify the changes in this request.

Delete this commented-out section before submitting your request.
-->

**Description**\
Updates Vagrantfile with support for M1 Mac's using an ARM-based box with Parallels.

**Context**\
As ARM-based devices become more popular it makes sense to provide a couple of easy-to-use options for development. Setting the ARCH environment variable will auto switch the Vagrantfile between x86/VirtualBox and ARM/Parallels boxes. As long as their Debian-based, Providence works the same once it's provisioning.

**Verification**\
Provide a clear and concise explanation here for any items not checked below.

- [x] I have read this project's code of conduct
- [x] I have read this project's contributing guidelines
- [x] I have followed this project's coding standards
- [x] I have followed this project's documentation standards
- [x] I have added passing tests to verify changes
