### PR TITLE
Update apt keyring management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Notable project changes. Versions are [semantic][].
 ## [Unreleased][]
 
 No unreleased changes.
+### Changed
+
+- Key management for apt sources
 
 ## [0.1.4][] - 2022-02-15
 

--- a/src/bin/apt.sh
+++ b/src/bin/apt.sh
@@ -8,21 +8,20 @@
 
 cd /etc/apt/sources.list.d || exit
 : >prov.list
-grep -qw apache /tmp/prov && echo "deb https://packages.sury.org/apache2 $LSBC main" >>prov.list
-grep -qw couchdb /tmp/prov && echo "deb https://apache.jfrog.io/artifactory/couchdb-deb $LSBC main" >>prov.list
-grep -qw docker /tmp/prov && echo "deb https://download.docker.com/linux/$LSBI $LSBC stable" >>prov.list
-grep -qw git /tmp/prov && echo "deb https://packagecloud.io/github/git-lfs/$LSBI $LSBC main" >>prov.list
-grep -qw github /tmp/prov && echo "deb https://cli.github.com/packages $LSBC main" >>prov.list
-grep -qw mariadb /tmp/prov && echo "deb https://downloads.mariadb.com/MariaDB/mariadb-$MARIA_VER/repo/$LSBI $LSBC main" >>prov.list
-grep -qw mongodb /tmp/prov && echo "deb https://repo.mongodb.org/apt/$LSBI $LSBC/mongodb-org/$MONGO_VER main" >>prov.list
-grep -qw nginx /tmp/prov && echo "deb https://packages.sury.org/nginx $LSBC main" >>prov.list
-grep -qw node /tmp/prov && wget -nc -qO /tmp/node.v https://deb.nodesource.com/setup_current.x && echo "deb https://deb.nodesource.com/$(grep ^NODEREPO= /tmp/node.v | cut -d= -f2 | tr -d '"') $LSBC main" >>prov.list
-grep -qw php /tmp/prov && echo "deb https://packages.sury.org/php $LSBC main" >>prov.list
-grep -qw postgres /tmp/prov && echo "deb https://apt.postgresql.org/pub/repos/apt $LSBC-pgdg main" >>prov.list
-grep -qw webmin /tmp/prov && echo 'deb https://download.webmin.com/download/repository sarge contrib' >>prov.list
+grep -qw apache /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-apache.gpg] https://packages.sury.org/apache2 $LSBC main" >>prov.list
+grep -qw couchdb /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-couchdb.asc] https://apache.jfrog.io/artifactory/couchdb-deb $LSBC main" >>prov.list
+grep -qw docker /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-docker.asc] https://download.docker.com/linux/$LSBI $LSBC stable" >>prov.list
+grep -qw git /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-git-lfs.asc] https://packagecloud.io/github/git-lfs/$LSBI $LSBC main" >>prov.list
+grep -qw mariadb /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-mariadb.asc] https://downloads.mariadb.com/MariaDB/mariadb-$MARIA_VER/repo/$LSBI $LSBC main" >>prov.list
+grep -qw mongodb /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-mongodb.asc] https://repo.mongodb.org/apt/$LSBI $LSBC/mongodb-org/$MONGO_VER main" >>prov.list
+grep -qw nginx /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-nginx.gpg] https://packages.sury.org/nginx $LSBC main" >>prov.list
+grep -qw node /tmp/prov && wget -nc -qO /tmp/node.v https://deb.nodesource.com/setup_current.x && echo "deb [signed-by=/usr/share/keyrings/prov-node.asc] https://deb.nodesource.com/$(grep ^NODEREPO= /tmp/node.v | cut -d= -f2 | tr -d '"') $LSBC main" >>prov.list
+grep -qw php /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-php.gpg] https://packages.sury.org/php $LSBC main" >>prov.list
+grep -qw postgres /tmp/prov && echo "deb [signed-by=/usr/share/keyrings/prov-postgresql.asc] https://apt.postgresql.org/pub/repos/apt $LSBC-pgdg main" >>prov.list
+grep -qw webmin /tmp/prov && echo 'deb [signed-by=/usr/share/keyrings/prov-webmin.asc] https://download.webmin.com/download/repository sarge contrib' >>prov.list
 cd "$VUD" || exit
 
-cd /etc/apt/trusted.gpg.d || exit
+cd /usr/share/keyrings || exit
 grep -qw apache /tmp/prov && wget -nc -qO prov-apache.gpg https://packages.sury.org/apache2/apt.gpg
 grep -qw couchdb /tmp/prov && wget -nc -qO prov-couchdb.asc https://couchdb.apache.org/repo/keys.asc
 grep -qw docker /tmp/prov && wget -nc -qO prov-docker.asc "https://download.docker.com/linux/$LSBI/gpg"


### PR DESCRIPTION
Update apt keyring management to use `/usr/share/keyrings` instead of `/etc/apt/trusted.gpg.d`.

**Description**\
Changes the way third-party apt sources are added and signed to the guest. Instead of adding keys directly to `/etc/apt/trusted.gpg.d`, keys are placed in `/usr/share/keyrings` and individual apt sources are tagged with the appropriate signing key in `/etc/apt/sources.list.d/prov.list`.

**Context**\
This brings Providence's apt sources in line with Debian best practices for third party repositories; see <https://wiki.debian.org/DebianRepository/UseThirdParty>

**Verification**\
Provide a clear and concise explanation here for any items not checked below.

- [x] I have read this project's code of conduct
- [x] I have read this project's contributing guidelines
- [x] I have followed this project's coding standards
- [x] I have followed this project's documentation standards
- [x] I have added passing tests to verify changes
