### PR TITLE
Add login shell functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Notable project changes. Versions are [semantic][].
 
 ## [Unreleased][]
 
-No unreleased changes.
+### Added
+
+- LOGIN_SHELL environment variable
+- LOGIN_SHELL_CNF environment variable
 
 ## [0.1.4][] - 2022-02-15
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -7,62 +7,75 @@ can specify most of them through your Vagrantfile. The following table
 summarizes the user-settable variables Providence recognizes. More information
 for specific variables is available below.
 
-| Variable           | Default value                                  | Implied keywords                         |
-| ------------------ | ---------------------------------------------- | ---------------------------------------- |
-| BUNDLER_CNF        | /vagrant/Gemfile                               | ruby                                     |
-| CARGO_CNF          | /vagrant/Cargo.toml                            | rust                                     |
-| CERT               | /etc/ssl/certs/ssl-cert-snakeoil.pem           | nginx                                    |
-| CKEY               | /etc/ssl/private/ssl-cert-snakeoil.key         | nginx                                    |
-| COMPOSER_CNF       | /vagrant/composer.json                         | php                                      |
-| DOCKER_CNF         | /vagrant/Dockerfile                            | docker                                   |
-| DOCKER_COMPOSE_CNF | /vagrant/docker-compose.yml                    | docker                                   |
-| GIT_DIR            | /vagrant/.git                                  | git                                      |
-| GITHUB_DIR         | /vagrant/.github                               | github                                   |
-| GO_VER             |                                                | go                                       |
-| HG_DIR             | /vagrant/.hg                                   | hg                                       |
-| HUGO_DIR           |                                                | hugo nginx                               |
-| HUGO_SRV           | /srv/web                                       |                                          |
-| JEKYLL_CNF         | First _config TOML or YAML file in JEKYLL_DIR  |                                          |
-| JEKYLL_DIR         | Directory containing JEKLL_CNF or BUNDLER_CNF  | jekyll nginx ruby                        |
-| JEKYLL_SRV         | /srv/web                                       |                                          |
-| [LANG][]           | en_US.UTF-8                                    |                                          |
-| MARIA_VER          | 10.5                                           | mariadb                                  |
-| MONGO_VER          | 5.0                                            | mongodb                                  |
-| NODE_CNF           | /vagrant/package.json                          | node                                     |
-| [NODE_VER][]       | Derived from NODE_CNF                          | node                                     |
-| PELICAN_CNF        | First *conf.py file in PELICAN_DIR             |                                          |
-| PELICAN_DIR        | Directory containing PELICAN_CNF or PIPENV_CNF | nginx pelican python                     |
-| PELICAN_SRV        | /srv/web                                       |                                          |
-| PERL_VER           |                                                | perl                                     |
-| [PHP_VER][]        | Dervied from WP_CNF or COMPOSER_CNF            | php                                      |
-| PIPENV_CNF         | /vagrant/Pipfile                               | python                                   |
-| [PROVIDENCE][]     | .                                              |                                          |
-| PYTHON_VER         | Derived fro PIPENV_CNF                         | python                                   |
-| [RUBY_VER][]       | Derived from BUNDLER_CNF                       | ruby                                     |
-| RUST_CNF           | /vagrant/rust-toolchain.toml                   | rust                                     |
-| RUST_VER           | Derived from RUST_CNF                          | rust                                     |
-| SHELLSPEC_CNF      | /vagrant/.shellspec                            | shell                                    |
-| SVN_DIR            | /vagrant/.svn                                  | svn                                      |
-| TEST_DIR           | /vagrant/test                                  |                                          |
-| WEB_DIR            |                                                | nginx                                    |
-| WEB_SRV            | /srv/web                                       |                                          |
-| WP_CNF             | WP_DIR/readme.txt                              |                                          |
-| [WP_DATA][]        | <https://github.com/WPTT/theme-test-data>      | apache mailhog mariadb php svn wordpress |
-| [WP_DIR][]         | Directory containing WP_CNF or COMPOSER_CNF    | apache mailhog mariadb php svn wordpress |
-| [WP_PLUGINS][]     | .                                              | apache mailhog mariadb php svn wordpress |
-| [WP_SRC][]         | <https://develop.svn.wordpress.org/branches>   | apache mailhog mariadb php svn wordpress |
-| WP_SRV             | /srv/web                                       |                                          |
-| [WP_THEME][]       |                                                | apache mailhog mariadb php svn wordpress |
-| [WP_THEMES][]      | .                                              | apache mailhog mariadb php svn wordpress |
-| [WP_VER][]         | Derived from WP_CNF or COMPOSER_CNF            | apache mailhog mariadb php svn wordpress |
-| ZOLA_CNF           | ZOLA_DIR/config.toml                           |                                          |
-| ZOLA_DIR           | Directory containing ZOLA_CNF                  | nginx zola                               |
-| ZOLA_SRV           | /srv/web                                       |                                          |
-| [ZONE][]           |                                                |                                          |
+| Variable            | Default value                                  | Implied keywords                         |
+| ------------------- | ---------------------------------------------- | ---------------------------------------- |
+| BUNDLER_CNF         | /vagrant/Gemfile                               | ruby                                     |
+| CARGO_CNF           | /vagrant/Cargo.toml                            | rust                                     |
+| CERT                | /etc/ssl/certs/ssl-cert-snakeoil.pem           | nginx                                    |
+| CKEY                | /etc/ssl/private/ssl-cert-snakeoil.key         | nginx                                    |
+| COMPOSER_CNF        | /vagrant/composer.json                         | php                                      |
+| DOCKER_CNF          | /vagrant/Dockerfile                            | docker                                   |
+| DOCKER_COMPOSE_CNF  | /vagrant/docker-compose.yml                    | docker                                   |
+| GIT_DIR             | /vagrant/.git                                  | git                                      |
+| GITHUB_DIR          | /vagrant/.github                               | github                                   |
+| GO_VER              |                                                | go                                       |
+| HG_DIR              | /vagrant/.hg                                   | hg                                       |
+| HUGO_DIR            |                                                | hugo nginx                               |
+| HUGO_SRV            | /srv/web                                       |                                          |
+| JEKYLL_CNF          | First _config TOML or YAML file in JEKYLL_DIR  |                                          |
+| JEKYLL_DIR          | Directory containing JEKLL_CNF or BUNDLER_CNF  | jekyll nginx ruby                        |
+| JEKYLL_SRV          | /srv/web                                       |                                          |
+| [LANG][]            | en_US.UTF-8                                    |                                          |
+| [LOGIN_SHELL][]     | /bin/bash                                      |                                          |
+| [LOGIN_SHELL_CNF][] | .bash_profile                                  |                                          |
+| MARIA_VER           | 10.5                                           | mariadb                                  |
+| MONGO_VER           | 5.0                                            | mongodb                                  |
+| NODE_CNF            | /vagrant/package.json                          | node                                     |
+| [NODE_VER][]        | Derived from NODE_CNF                          | node                                     |
+| PELICAN_CNF         | First *conf.py file in PELICAN_DIR             |                                          |
+| PELICAN_DIR         | Directory containing PELICAN_CNF or PIPENV_CNF | nginx pelican python                     |
+| PELICAN_SRV         | /srv/web                                       |                                          |
+| PERL_VER            |                                                | perl                                     |
+| [PHP_VER][]         | Dervied from WP_CNF or COMPOSER_CNF            | php                                      |
+| PIPENV_CNF          | /vagrant/Pipfile                               | python                                   |
+| [PROVIDENCE][]      | .                                              |                                          |
+| PYTHON_VER          | Derived from PIPENV_CNF                        | python                                   |
+| [RUBY_VER][]        | Derived from BUNDLER_CNF                       | ruby                                     |
+| RUST_CNF            | /vagrant/rust-toolchain.toml                   | rust                                     |
+| RUST_VER            | Derived from RUST_CNF                          | rust                                     |
+| SHELLSPEC_CNF       | /vagrant/.shellspec                            | shell                                    |
+| SVN_DIR             | /vagrant/.svn                                  | svn                                      |
+| TEST_DIR            | /vagrant/test                                  |                                          |
+| WEB_DIR             |                                                | nginx                                    |
+| WEB_SRV             | /srv/web                                       |                                          |
+| WP_CNF              | WP_DIR/readme.txt                              |                                          |
+| [WP_DATA][]         | <https://github.com/WPTT/theme-test-data>      | apache mailhog mariadb php svn wordpress |
+| [WP_DIR][]          | Directory containing WP_CNF or COMPOSER_CNF    | apache mailhog mariadb php svn wordpress |
+| [WP_PLUGINS][]      | .                                              | apache mailhog mariadb php svn wordpress |
+| [WP_SRC][]          | <https://develop.svn.wordpress.org/branches>   | apache mailhog mariadb php svn wordpress |
+| WP_SRV              | /srv/web                                       |                                          |
+| [WP_THEME][]        |                                                | apache mailhog mariadb php svn wordpress |
+| [WP_THEMES][]       | .                                              | apache mailhog mariadb php svn wordpress |
+| [WP_VER][]          | Derived from WP_CNF or COMPOSER_CNF            | apache mailhog mariadb php svn wordpress |
+| ZOLA_CNF            | ZOLA_DIR/config.toml                           |                                          |
+| ZOLA_DIR            | Directory containing ZOLA_CNF                  | nginx zola                               |
+| ZOLA_SRV            | /srv/web                                       |                                          |
+| [ZONE][]            |                                                |                                          |
 
 ## LANG
 
 Guest locale. Must be a locale recognized by the guest.
+
+## LOGIN_SHELL
+
+Login shell to use. Defaults to `/bin/bash`. Providence will attempt to install
+the preferred shell if LOGIN_SHELL is not listed in `/etc/shells`.
+
+## LOGIN_SHELL_CNF
+
+Login shell config filename. Defaults to `.bash_profile`. Providence will source
+`.profile` and add PATH updates and `eval` calls from applications like `nodenv`
+to this file on the guest.
 
 ## NODE_VER
 
@@ -273,6 +286,8 @@ Guest time zone. Must be a valid tz database value (e.g. `America/Detroit`).
 [lang]: #lang
 [log-deprecated-notices]: https://wordpress.org/plugins/log-deprecated-notices
 [log-viewer]: https://wordpress.org/plugins/log-viewer
+[login_shell_cnf]: #login_shell_cnf
+[login_shell]: #login_shell
 [mailhog]: https://github.com/mailhog/MailHog
 [mariadb]: https://mariadb.org
 [memcached]: https://memcached.org

--- a/src/bin/apt.sh
+++ b/src/bin/apt.sh
@@ -48,6 +48,7 @@ ssl-cert
 unzip
 vim
 zip
+$(grep -q "$LOGIN_SHELL" /etc/shells || echo "$LOGIN_SHELL" | rev | cut -d/ -f1 | rev)
 _
 grep -qw apache /tmp/prov && cat <<_ >>/tmp/prov-apt
 apache2

--- a/src/bin/goenv.sh
+++ b/src/bin/goenv.sh
@@ -10,7 +10,7 @@ if grep -qw go /tmp/prov
   wget -nc -qO /tmp/goenv.tar.gz https://api.github.com/repos/syndbg/goenv/tarball
   tar -xkf /tmp/goenv.tar.gz -C .goenv --strip-components 1 2>/dev/null
 
-  cat <<_ >.bash_goenv
+  cat <<_ >.prov_goenv
 export GOPATH=$VUD/.go
 export GOENV_GOPATH_PREFIX=\$GOPATH
 export GOENV_ROOT=$VUD/.goenv
@@ -19,9 +19,9 @@ eval "\$(goenv init -)"
 export PATH=\$GOROOT/bin:\$PATH:\$GOPATH/bin
 _
 
-  [ -n "$GOENV_ROOT" ] || . "$VUD/.bash_goenv"
-  grep -q '\.bash_goenv' .bash_profile || echo '. ~/.bash_goenv' >>.bash_profile
-  grep -q '\.bash_goenv' /root/.bash_profile || echo ". $VUD/.bash_goenv" >>/root/.bash_profile
+  [ -n "$GOENV_ROOT" ] || . "$VUD/.prov_goenv"
+  grep -q '\.prov_goenv' "$LOGIN_SHELL_CNF" || echo '. ~/.prov_goenv' >>"$LOGIN_SHELL_CNF"
+  grep -q '\.prov_goenv' "/root/$LOGIN_SHELL_CNF" || echo ". $VUD/.prov_goenv" >>"/root/$LOGIN_SHELL_CNF"
 
   if [ -n "$GO_VER" ] && ! goenv global | grep -qw "$GO_VER"
     then echo "Installing Go $GO_VER"

--- a/src/bin/nodenv.sh
+++ b/src/bin/nodenv.sh
@@ -19,15 +19,15 @@ if grep -qw node /tmp/prov
   make -sC src
   cd "$VUD" || exit
 
-  cat <<_ >.bash_nodenv
+  cat <<_ >.prov_nodenv
 export NODENV_ROOT=$VUD/.nodenv
 export PATH=\$NODENV_ROOT/bin:\$PATH
 eval "\$(nodenv init -)"
 _
 
-  [ -n "$NODENV_ROOT" ] || . "$VUD/.bash_nodenv"
-  grep -q '\.bash_nodenv' .bash_profile || echo '. ~/.bash_nodenv' >>.bash_profile
-  grep -q '\.bash_nodenv' /root/.bash_profile || echo ". $VUD/.bash_nodenv" >>/root/.bash_profile
+  [ -n "$NODENV_ROOT" ] || . "$VUD/.prov_nodenv"
+  grep -q '.prov_nodenv' "$LOGIN_SHELL_CNF" || echo '. ~/.prov_nodenv' >>"$LOGIN_SHELL_CNF"
+  grep -q '.prov_nodenv' "/root/$LOGIN_SHELL_CNF" || echo ". $VUD/.prov_nodenv" >>"/root/$LOGIN_SHELL_CNF"
 
   if [ -n "$NODE_VER" ] && ! nodenv global | grep -qw "$NODE_VER"
     then echo "Installing Node $NODE_VER"

--- a/src/bin/plenv.sh
+++ b/src/bin/plenv.sh
@@ -15,15 +15,15 @@ if grep -qw perl /tmp/prov
   wget -nc -qO /tmp/perl-build.tar.gz https://api.github.com/repos/tokuhirom/perl-build/tarball
   tar -xkf /tmp/perl-build.tar.gz -C .plenv/plugins/perl-build --strip-components 1 2>/dev/null
 
-  cat <<_ >.bash_plenv
+  cat <<_ >.prov_plenv
 export PLENV_ROOT=$VUD/.plenv
 export PATH=\$PLENV_ROOT/bin:\$PATH
 eval "\$(plenv init -)"
 _
 
-  [ -n "$PLENV_ROOT" ] || . "$VUD/.bash_plenv"
-  grep -q '\.bash_plenv' .bash_profile || echo '. ~/.bash_plenv' >>.bash_profile
-  grep -q '\.bash_plenv' /root/.bash_profile || echo ". $VUD/.bash_plenv" >>/root/.bash_profile
+  [ -n "$PLENV_ROOT" ] || . "$VUD/.prov_plenv"
+  grep -q '\.prov_plenv' "$LOGIN_SHELL_CNF" || echo '. ~/.prov_plenv' >>"$LOGIN_SHELL_CNF"
+  grep -q '\.prov_plenv' "/root/$LOGIN_SHELL_CNF" || echo ". $VUD/.prov_plenv" >>"/root/$LOGIN_SHELL_CNF"
 
   if [ -n "$PERL_VER" ] && ! plenv global | grep -qw "$PERL_VER"
     then echo "Installing Perl $PERL_VER"

--- a/src/bin/pyenv.sh
+++ b/src/bin/pyenv.sh
@@ -10,16 +10,16 @@ if grep -qw python /tmp/prov
   wget -nc -qO /tmp/pyenv.tar.gz https://api.github.com/repos/pyenv/pyenv/tarball
   tar -xkf /tmp/pyenv.tar.gz -C .pyenv --strip-components 1 2>/dev/null
 
-  cat <<_ >.bash_pyenv
+  cat <<_ >.prov_pyenv
 export PIPENV_VENV_IN_PROJECT=:
 export PYENV_ROOT=$VUD/.pyenv
 export PATH=\$PYENV_ROOT/bin:$VUD/.local/bin:\$PATH
 eval "\$(pyenv init -)"
 _
 
-  [ -n "$PYENV_ROOT" ] || . "$VUD/.bash_pyenv"
-  grep -q '\.bash_pyenv' .bash_profile || echo '. ~/.bash_pyenv' >>.bash_profile
-  grep -q '\.bash_pyenv' /root/.bash_profile || echo ". $VUD/.bash_pyenv" >>/root/.bash_profile
+  [ -n "$PYENV_ROOT" ] || . "$VUD/.prov_pyenv"
+  grep -q '\.prov_pyenv' "$LOGIN_SHELL_CNF" || echo '. ~/.prov_pyenv' >>"$LOGIN_SHELL_CNF"
+  grep -q '\.prov_pyenv' "/root/$LOGIN_SHELL_CNF" || echo ". $VUD/.prov_pyenv" >>"/root/$LOGIN_SHELL_CNF"
 
   if [ -n "$PYTHON_VER" ] && ! pyenv global | grep -qw "$PYTHON_VER"
     then echo "Installing Python $PYTHON_VER"

--- a/src/bin/rbenv.sh
+++ b/src/bin/rbenv.sh
@@ -19,15 +19,15 @@ if grep -qw ruby /tmp/prov
   make -sC src
   cd "$VUD" || exit
 
-  cat <<_ >.bash_rbenv
+  cat <<_ >.prov_rbenv
 export RBENV_ROOT=$VUD/.rbenv
 export PATH=\$RBENV_ROOT/bin:\$PATH
 eval "\$(rbenv init -)"
 _
 
-  [ -n "$RBENV_ROOT" ] || . "$VUD/.bash_rbenv"
-  grep -q '\.bash_rbenv' .bash_profile || echo '. ~/.bash_rbenv' >>.bash_profile
-  grep -q '\.bash_rbenv' /root/.bash_profile || echo ". $VUD/.bash_rbenv" >>/root/.bash_profile
+  [ -n "$RBENV_ROOT" ] || . "$VUD/.prov_rbenv"
+  grep -q '\.prov_rbenv' "$LOGIN_SHELL_CNF" || echo '. ~/.prov_rbenv' >>"$LOGIN_SHELL_CNF"
+  grep -q '\.prov_rbenv' "/root/$LOGIN_SHELL_CNF" || echo ". $VUD/.prov_rbenv" >>"/root/$LOGIN_SHELL_CNF"
 
   if [ -n "$RUBY_VER" ] && ! rbenv global | grep -qw "$RUBY_VER"
     then echo "Installing Ruby $RUBY_VER"

--- a/src/bin/rustup.sh
+++ b/src/bin/rustup.sh
@@ -12,7 +12,7 @@ if grep -qw rust /tmp/prov
   rustup-init -y >/dev/null 2>/dev/null
 
   echo "$PATH" | grep -q '/\.cargo/' || . "$VUD/.cargo/env"
-  grep -q '\.cargo' .bash_profile || echo '. ~/.cargo/env' >>.bash_profile
+  grep -q '\.cargo' "$LOGIN_SHELL_CNF" || echo '. ~/.cargo/env' >>"$LOGIN_SHELL_CNF"
 
   if [ -n "$RUST_VER" ] && ! rustup default | cut -d- -f1 | grep -qw "$RUST_VER"
     then echo "Installing Rust $RUST_VER"

--- a/src/init.sh
+++ b/src/init.sh
@@ -20,12 +20,6 @@ locale-gen "$LANG" >/dev/null
 update-locale LANG="$LANG"
 [ -n "$ZONE" ] && [ -s "/usr/share/zoneinfo/$ZONE" ] && timedatectl set-timezone "$ZONE"
 
-touch .profile /root/.profile
-[ -s .bash_profile ] || echo '' >.bash_profile
-[ -s /root/.bash_profile ] || echo '' >/root/.bash_profile
-grep -q '\.profile' .bash_profile || sed -i '1 i\. ~/.profile' .bash_profile
-grep -q '\.profile' /root/.bash_profile || sed -i '1 i\. ~/.profile' /root/.bash_profile
-
 : "${BUNDLER_CNF:=/vagrant/Gemfile}"
 : "${CARGO_CNF:=/vagrant/Cargo.toml}"
 : "${COMPOSER_CNF:=/vagrant/composer.json}"
@@ -34,7 +28,8 @@ grep -q '\.profile' /root/.bash_profile || sed -i '1 i\. ~/.profile' /root/.bash
 : "${GIT_DIR:=/vagrant/.git}"
 : "${GITHUB_DIR:=/vagrant/.github}"
 : "${HG_DIR:=/vagrant/.hg}"
-: "${HOST:=@ sys.@}"
+: "${LOGIN_SHELL:=/bin/bash}"
+: "${LOGIN_SHELL_CNF:=.bash_profile}"
 : "${NODE_CNF:=/vagrant/package.json}"
 : "${PIPENV_CNF:=/vagrant/Pipfile}"
 : "${PROVIDENCE:=.}"
@@ -42,6 +37,12 @@ grep -q '\.profile' /root/.bash_profile || sed -i '1 i\. ~/.profile' /root/.bash
 : "${SHELLSPEC_CNF:=/vagrant/.shellspec}"
 : "${SVN_DIR:=/vagrant/.svn}"
 : "${TEST_DIR:=/vagrant/test}"
+
+touch .profile /root/.profile
+[ -s $LOGIN_SHELL_CNF ] || echo '' >$LOGIN_SHELL_CNF
+[ -s /root/$LOGIN_SHELL_CNF ] || echo '' >/root/$LOGIN_SHELL_CNF
+grep -q '\.profile' $LOGIN_SHELL_CNF || sed -i '1 i\. ~/.profile' $LOGIN_SHELL_CNF
+grep -q '\.profile' /root/$LOGIN_SHELL_CNF || sed -i '1 i\. ~/.profile' /root/$LOGIN_SHELL_CNF
 
 [ -z "$JEKYLL_DIR" ] && [ -s "$JEKYLL_CNF" ] && JEKYLL_DIR=$(dirname "$JEKYLL_CNF")
 [ -z "$JEKYLL_DIR" ] && grep -qs '\bjekyll' "$BUNDLER_CNF" && JEKYLL_DIR=$(dirname "$BUNDLER_CNF")

--- a/src/term.sh
+++ b/src/term.sh
@@ -66,6 +66,9 @@ chown -R www-data:www-data /srv
 service --status-all | grep -q '+.*apache2' && service apache2 restart
 service --status-all | grep -q '+.*nginx' && service nginx restart
 
+chsh -s "$LOGIN_SHELL"
+chsh -s "$LOGIN_SHELL" vagrant
+
 term=$(date +%s)
 mins=$(((term - init) / 60))
 secs=$((term - init - mins * 60))


### PR DESCRIPTION
<!--
Provide a brief, descriptive summary of your changes in the title above.

Use appropriate labels to identify the changes in this request.

Delete this commented-out section before submitting your request.
-->

**Description**\
Adds two new environment variables, LOGIN_SHELL and LOGIN_SHELL_CNF, that will switch the login shell used by `root` and `vagrant` during provisioning.

**Context**\
A minor change that provides a some extra flexibility in how you interact with the guest. If you prefer `zsh` over `bash`, for example, you can now set `LOGIN_SHELL=/bin/zsh` and `LOGIN_SHELL_CNF=.zlogin` and Providence will do the rest.

**Verification**\
Provide a clear and concise explanation here for any items not checked below.

- [x] I have read this project's code of conduct
- [x] I have read this project's contributing guidelines
- [x] I have followed this project's coding standards
- [x] I have followed this project's documentation standards
- [x] I have added passing tests to verify changes
